### PR TITLE
fixed crash when deleting all QR codes

### DIFF
--- a/app/src/main/java/com/example/qrrush/model/FirebaseWrapper.java
+++ b/app/src/main/java/com/example/qrrush/model/FirebaseWrapper.java
@@ -124,7 +124,7 @@ public class FirebaseWrapper {
             Map<String, Object> updates = new HashMap<>();
             updates.put("qrcodes", FieldValue.arrayRemove(hash));
 
-            if (comments.size() > 0) {
+            if (comments.size() > 0 && comments.size() >= hashes.size()) {
                 String comment = comments.get(hashes.indexOf(hash));
                 updates.put("qrcodescomments", FieldValue.arrayRemove(comment));
             }


### PR DESCRIPTION
So this was a bug I couldn't reliably reproduce, but once it happened I was able to find the line it happened on and fixed it.
I restarted the app once it began happening and after this change it wouldn't happen again so I think this fixed it.